### PR TITLE
refactor: use renderingToken instead of secureId

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Resume.io to PDF
 
 Download your resume from [resume.io](https://resume.io) as a PDF file. Open the application, enter your resume 
-`secureId` and click the download button. It will automatically download your resume as image files, merge and 
+`renderingToken` and click the download button. It will automatically download your resume as image files, merge and 
 convert them to a PDF file, and run OCR to extract the text and make it searchable.
 
 <div align="center"><a href="https://resumeio-to-pdf.fly.dev/"><img src="https://github.com/felipeall/resumeio-to-pdf/assets/20917430/a0479dc5-ceb8-4532-826d-eae98649a089" width="700" /></a></div>
 
 
-#### How to find your secureId
+#### How to find your renderingToken
 
 Go to https://resume.io/api/app/resumes
 
-You will see a list of your resumes. Find the one you want to download and get the `secureId` from 
+You will see a list of your resumes. Find the one you want to download and get the `renderingToken` from 
 the payload. Example:
 
 ![image](https://github.com/felipeall/resumeio-to-pdf/assets/20917430/54fb20b3-2dc1-45ca-860c-8eadac779799)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Go to https://resume.io/api/app/resumes
 You will see a list of your resumes. Find the one you want to download and get the `renderingToken` from 
 the payload. Example:
 
-![image](https://github.com/felipeall/resumeio-to-pdf/assets/20917430/54fb20b3-2dc1-45ca-860c-8eadac779799)
+<img src="https://github.com/felipeall/resumeio-to-pdf/assets/20917430/99cdc690-9c38-4f5f-af4e-2c75e9c9575e" width="500" />
+
 
 
 ### Usage

--- a/app/api/api.py
+++ b/app/api/api.py
@@ -18,7 +18,7 @@ def download_resume(rendering_token: str, image_size: int = 3000, extension: str
     Parameters
     ----------
     rendering_token : str
-        ID of the resume to download.
+        Rendering Token of the resume to download.
     image_size : int, optional
         Size of the images to download, by default 3000.
     extension : str, optional
@@ -58,12 +58,12 @@ def index(request: Request):
 
 def parse_rendering_token(rendering_token: str) -> str:
     """
-    Parse a resume.io ID or URL.
+    Parse a resume.io Rendering Token.
 
     Parameters
     ----------
     rendering_token : str
-        ID of the resume to parse.
+        Rendering Token of the resume to parse.
 
     Returns
     -------
@@ -71,8 +71,8 @@ def parse_rendering_token(rendering_token: str) -> str:
         The resume's rendering token.
 
     """
-    match = re.search(r"^(?P<id>[a-zA-Z0-9]{24})$", rendering_token)
+    match = re.search(r"^(?P<rendering_token>[a-zA-Z0-9]{24})$", rendering_token)
     if not match:
-        raise HTTPException(status_code=400, detail=f"Invalid resumeio.io ID or URL: {rendering_token}")
+        raise HTTPException(status_code=400, detail=f"Invalid rendering token: {rendering_token}")
 
-    return match.groupdict().get("id")
+    return match.groupdict().get("rendering_token")

--- a/app/api/api.py
+++ b/app/api/api.py
@@ -33,7 +33,8 @@ def download_resume(rendering_token: str, image_size: int = 3000, extension: str
     resumeio = ResumeioDownloader(rendering_token=rendering_token, image_size=image_size, extension=extension)
     buffer = resumeio.generate_pdf()
     return Response(
-        buffer, headers={"Content-Disposition": f'inline; filename="{rendering_token}.pdf"'}, media_type="application/pdf",
+        buffer,
+        headers={"Content-Disposition": f'inline; filename="{rendering_token}.pdf"'}, media_type="application/pdf",
     )
 
 

--- a/app/api/api.py
+++ b/app/api/api.py
@@ -70,7 +70,7 @@ def parse_resume_id(resume_input: str) -> str:
         The resume ID.
 
     """
-    match = re.search(r"^(.+resume\.io/r/)?(?P<id>[a-zA-Z0-9]{9})$", resume_input)
+    match = re.search(r"^(.+resume\.io/r/)?(?P<id>[a-zA-Z0-9]+)$", resume_input)
     if not match:
         raise HTTPException(status_code=400, detail=f"Invalid resumeio.io ID or URL: {resume_input}")
 

--- a/app/services/resumeio.py
+++ b/app/services/resumeio.py
@@ -18,19 +18,19 @@ class ResumeioDownloader:
 
     Parameters
     ----------
-    resume_id : str
-        ID or URL of the resume to download.
+    rendering_token : str
+        ID of the resume to download.
     extension : str, optional
         Image extension to download, by default "jpg".
     image_size : int, optional
         Size of the images to download, by default 3000.
     """
-    resume_id: str
+    rendering_token: str
     extension: str = "jpg"
     image_size: int = 3000
-    METADATA_URL: str = "https://ssr.resume.tools/meta/{resume_id}?cache={cache_date}"
+    METADATA_URL: str = "https://ssr.resume.tools/meta/{rendering_token}?cache={cache_date}"
     IMAGES_URL: str = (
-        "https://ssr.resume.tools/to-image/{resume_id}-{page_id}.{extension}?cache={cache_date}&size={image_size}"
+        "https://ssr.resume.tools/to-image/{rendering_token}-{page_id}.{extension}?cache={cache_date}&size={image_size}"
     )
 
     def __post_init__(self) -> None:
@@ -71,7 +71,7 @@ class ResumeioDownloader:
 
     def __get_resume_metadata(self) -> None:
         """Download the metadata for the resume."""
-        response = requests.get(self.METADATA_URL.format(resume_id=self.resume_id, cache_date=self.cache_date))
+        response = requests.get(self.METADATA_URL.format(rendering_token=self.rendering_token, cache_date=self.cache_date))
         self.__raise_for_status(response)
         content = json.loads(response.text)
         self.metadata = content.get("pages")
@@ -87,7 +87,7 @@ class ResumeioDownloader:
         images = []
         for page_id in range(1, 1 + len(self.metadata)):
             image_url = self.IMAGES_URL.format(
-                resume_id=self.resume_id,
+                rendering_token=self.rendering_token,
                 page_id=page_id,
                 extension=self.extension,
                 cache_date=self.cache_date,
@@ -129,4 +129,4 @@ class ResumeioDownloader:
             If the response status code is not 200.
         """
         if response.status_code != 200:
-            raise HTTPException(status_code=response.status_code, detail=f"Unable to download resume {self.resume_id}")
+            raise HTTPException(status_code=response.status_code, detail=f"Unable to download resume {self.rendering_token}")

--- a/app/services/resumeio.py
+++ b/app/services/resumeio.py
@@ -28,9 +28,9 @@ class ResumeioDownloader:
     resume_id: str
     extension: str = "jpg"
     image_size: int = 3000
-    METADATA_URL: str = "https://ssr.resume.tools/meta/ssid-{resume_id}?cache={cache_date}"
+    METADATA_URL: str = "https://ssr.resume.tools/meta/{resume_id}?cache={cache_date}"
     IMAGES_URL: str = (
-        "https://ssr.resume.tools/to-image/ssid-{resume_id}-{page_id}.{extension}?cache={cache_date}&size={image_size}"
+        "https://ssr.resume.tools/to-image/{resume_id}-{page_id}.{extension}?cache={cache_date}&size={image_size}"
     )
 
     def __post_init__(self) -> None:

--- a/app/services/resumeio.py
+++ b/app/services/resumeio.py
@@ -71,7 +71,9 @@ class ResumeioDownloader:
 
     def __get_resume_metadata(self) -> None:
         """Download the metadata for the resume."""
-        response = requests.get(self.METADATA_URL.format(rendering_token=self.rendering_token, cache_date=self.cache_date))
+        response = requests.get(
+            self.METADATA_URL.format(rendering_token=self.rendering_token, cache_date=self.cache_date),
+        )
         self.__raise_for_status(response)
         content = json.loads(response.text)
         self.metadata = content.get("pages")
@@ -129,4 +131,7 @@ class ResumeioDownloader:
             If the response status code is not 200.
         """
         if response.status_code != 200:
-            raise HTTPException(status_code=response.status_code, detail=f"Unable to download resume {self.rendering_token}")
+            raise HTTPException(
+                status_code=response.status_code,
+                detail=f"Unable to download resume {self.rendering_token}",
+            )

--- a/app/services/resumeio.py
+++ b/app/services/resumeio.py
@@ -19,7 +19,7 @@ class ResumeioDownloader:
     Parameters
     ----------
     rendering_token : str
-        ID of the resume to download.
+        Rendering Token of the resume to download.
     extension : str, optional
         Image extension to download, by default "jpg".
     image_size : int, optional
@@ -133,5 +133,5 @@ class ResumeioDownloader:
         if response.status_code != 200:
             raise HTTPException(
                 status_code=response.status_code,
-                detail=f"Unable to download resume {self.rendering_token}",
+                detail=f"Unable to download resume (rendering token: {self.rendering_token})",
             )

--- a/templates/index.html
+++ b/templates/index.html
@@ -75,11 +75,9 @@
     <h1 class="title">Resume.io to PDF</h1>
     <iframe class="github-button" src="https://ghbtns.com/github-btn.html?user=felipeall&repo=resumeio-to-pdf&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
     <form method="get" class="resume_form" action='/download{{ rendering_token }}'>
-        <input type="text" class="resume" name="rendering_token" placeholder="Enter your resume Rendering Token to download"
-               aria-label="Id" required="true">
+        <input type="text" class="resume" name="rendering_token" placeholder="Enter your resume Rendering Token to download" aria-label="Id" required="true" minlength="24" maxlength="24">
         <button id="submit-btn" class="btn" type="submit"><span id="submit-text">Download</span>
-            <svg id="loader" width="23" height="23" stroke="#fff" viewBox="0 0 24 24"
-                 xmlns="http://www.w3.org/2000/svg">
+            <svg id="loader" width="23" height="23" stroke="#fff" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <style>.spinner_V8m1 {
                     transform-origin: center;
                     animation: spinner_zKoa 2s linear infinite

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,8 +74,8 @@
 <div class="container">
     <h1 class="title">Resume.io to PDF</h1>
     <iframe class="github-button" src="https://ghbtns.com/github-btn.html?user=felipeall&repo=resumeio-to-pdf&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub"></iframe>
-    <form method="get" class="resume_form" action='/download{{ resume }}'>
-        <input type="text" class="resume" name="resume" placeholder="Enter your resume ID or URL to download"
+    <form method="get" class="resume_form" action='/download{{ rendering_token }}'>
+        <input type="text" class="resume" name="rendering_token" placeholder="Enter your resume Rendering Token to download"
                aria-label="Id" required="true">
         <button id="submit-btn" class="btn" type="submit"><span id="submit-text">Download</span>
             <svg id="loader" width="23" height="23" stroke="#fff" viewBox="0 0 24 24"


### PR DESCRIPTION
# Summary
Updates the app to use `renderingToken` instead of `secureId` due to resume.io omitting that information in a recent update.

@felipeall, could you update the README's image highlighting renderingToken? Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the method for downloading resumes from resume.io to use `renderingToken` instead of `secureId`.
- **Bug Fixes**
	- Improved resume ID identification by modifying the regular expression pattern to allow alphanumeric characters.
- **Documentation**
	- Updated instructions and UI elements to reflect changes in resume downloading process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->