### PR TITLE
Less docker commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  resumeio-to-pdf:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: resumeio-to-pdf
+    ports:
+    - "8000:8000"


### PR DESCRIPTION
Users now only need to clone the repo and do:
```
docker-compose up
```
instead of building and running manually