### PR TITLE
Updated README with Cover letter url

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ convert to a PDF file and run OCR to extract the text.
 
 ### How to find your renderingToken
 
+For resume:
 Go to https://resume.io/api/app/resumes
+
+For cover letters:
+Go to https://resume.io/api/app/cover-letters/
 
 You will see a list of your resumes. Find the one you want to download and get the `renderingToken` from 
 the payload.


### PR DESCRIPTION
You can download the cover letters also.
I check in https://resume.io/api/app/cover-letters/ and it works. 
Just wanted to update if someone wanted to download the cover letters also. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with instructions for obtaining `renderingToken` for cover letters
	- Added guidance on accessing cover letter functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->