### PR TITLE
Fixes #45: update base image in Dockerfile to python:3.9-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.16-slim-buster
+FROM python:3.9-slim-bookworm
 
 # Update, install tesseract, clean up
 RUN apt-get update  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bookworm
+FROM python:3.9.19-slim-bookworm   # lock to the tested 3.9.x patch for deterministic builds
 
 # Update, install tesseract, clean up
 RUN apt-get update  \


### PR DESCRIPTION
Update Python Docker Base Image

Summary
Updated the base image in the Dockerfile from python:3.9.16-slim-buster to python:3.9-slim-bookworm.

Why
	•	buster is deprecated and no longer receives security updates
	•	bookworm is the current stable Debian release
	•	Improves security, compatibility, and long-term maintainability

Fixes #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the base Docker image to use a newer Debian version for improved compatibility and support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->