### PR TITLE
argument adjustment for TemplateResponse

### DIFF
--- a/app/api/api.py
+++ b/app/api/api.py
@@ -56,4 +56,8 @@ def index(request: Request):
     fastapi.templating.Jinja2Templates.TemplateResponse
         Rendered template of the main index page.
     """
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(
+    request,
+    "index.html",
+    {"request": request}
+)


### PR DESCRIPTION
just a small fix to make the container work


before:

    return templates.TemplateResponse("index.html", {"request": request})

after:
    return templates.TemplateResponse(
    request,
    "index.html",
    {"request": request}
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal adjustment to template response handling. No user-facing functionality has been affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->