### PR TITLE
fix: handle resume.io API changes breaking PDF generation

### DIFF
--- a/app/api/api.py
+++ b/app/api/api.py
@@ -14,7 +14,7 @@ templates = Jinja2Templates(directory="templates")
 @router.post("/download/{rendering_token}")
 def download_resume(
     rendering_token: Annotated[str, Path(min_length=24, max_length=24, pattern="^[a-zA-Z0-9]{24}$")],
-    image_size: Annotated[int, Query(gt=0)] = 3000,
+    image_size: Annotated[int, Query(gt=0, le=2000)] = 2000,
     extension: Annotated[Extension, Query()] = Extension.jpeg,
 ):
     """

--- a/app/services/resumeio.py
+++ b/app/services/resumeio.py
@@ -30,7 +30,7 @@ class ResumeioDownloader:
 
     rendering_token: str
     extension: Extension = Extension.jpeg
-    image_size: int = 3000
+    image_size: int = 2000
     METADATA_URL: str = "https://ssr.resume.tools/meta/{rendering_token}?cache={cache_date}"
     IMAGES_URL: str = (
         "https://ssr.resume.tools/to-image/{rendering_token}-{page_id}.{extension}?cache={cache_date}&size={image_size}"
@@ -60,7 +60,7 @@ class ResumeioDownloader:
             page_scale = max(page.mediabox.height / metadata_h, page.mediabox.width / metadata_w)
             pdf.add_page(page)
 
-            for link in self.metadata[i].get("links"):
+            for link in self.metadata[i].get("links") or []:
                 link_url = link.pop("url")
                 link.update((k, v * page_scale) for k, v in link.items())
                 x, y, w, h = link.values()


### PR DESCRIPTION
## Summary

PDF generation is currently broken against the live resume.io / `ssr.resume.tools` API. Two independent regressions:

### 1. `image_size=3000` now returns a placeholder

`ssr.resume.tools/to-image/<token>-<page>.jpeg?size=...` silently caps the `size` parameter. Anything above **2000** returns a 5449-byte placeholder PNG (a "broken document" icon) with `content-type: image/png` even when `.jpeg` is requested:

```
size=2000 -> 200 image/jpeg 543636
size=2010 -> 200 image/png    5449   <- placeholder
size=3000 -> 200 image/png    5449   <- placeholder (current default)
```

The result is a PDF where every page is the broken-document icon. Lowering the default to `2000` and clamping the `image_size` query parameter to `le=2000` fixes this end-to-end.

### 2. `links` may be missing from a page's metadata

The `/meta/<token>` response no longer guarantees a `links` key on every page. The current loop crashes with:

```
File "/app/app/services/resumeio.py", line 63, in generate_pdf
    for link in self.metadata[i].get("links"):
TypeError: 'NoneType' object is not iterable
```

`get("links") or []` makes the loop a no-op when the key is absent or null, which is the correct behavior (a page with no hyperlinks just gets no link annotations).

## Test plan

- [x] Reproduced the 500 against a real rendering token, confirmed the traceback above
- [x] Confirmed `size=3000` returns the 5KB placeholder PNG; `size=2000` returns a real ~540KB JPEG (binary-search narrowed the cap to exactly 2000)
- [x] Rebuilt the Docker image with both fixes and confirmed `POST /download/<token>` now returns a 571KB PDF rendering the real resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resume PDF processing error when pages lack link metadata.

* **Improvements**
  * Reduced default resume image size from 3000 to 2000 pixels and enforced a maximum limit of 2000 pixels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->