### PR TITLE
Render every page with resume.io's client-side worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.12.13-slim
 RUN apt-get update  \
     && apt-get install -y --no-install-recommends \
     tesseract-ocr \
+    nodejs \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,22 @@ Download your resume from [resume.io](https://resume.io) as a PDF file.
 
 <div align="center"><a href="https://resumeio-to-pdf.fly.dev/"><img src="https://github.com/felipeall/resumeio-to-pdf/assets/20917430/b7edfda4-4768-4659-af68-561e1effe628" width="700" /></a></div>
 
-Open the application, enter your resume `renderingToken` and click the download button. 
-It will automatically download the first page of your resume as an image, convert it to a PDF file and run OCR to extract the text.
+Open the application, paste your resume JSON and click the download button. It renders every page with
+resume.io's own rendering worker, so the PDF keeps selectable text instead of being an OCR'd image.
 
-> **Note:** Due to recent changes in resume.io's rendering service, only the first page of the resume can be downloaded and the maximum image resolution is capped at 2000px.
+### How to find your resume JSON
 
-### How to find your renderingToken
+Open https://resume.io/api/app/resumes while logged in, find the resume you want and note its `id`.
+Then open `https://resume.io/api/app/resumes/{id}` and copy the whole payload.
 
-Resumes: https://resume.io/api/app/resumes
+### Downloading a single page instead
 
-Cover Letters: https://resume.io/api/app/cover-letters/
+Entering a `renderingToken` still downloads the first page as an image, converts it to a PDF file and runs
+OCR to extract the text. That path needs no login, but resume.io's image endpoint only ever renders page one
+and caps the resolution at 2000px.
 
-You will see a list of your resumes. Find the one you want to download and get the `renderingToken` from 
-the payload.
+You will find the `renderingToken` in the same payload, and for cover letters under
+https://resume.io/api/app/cover-letters/.
 
 ### How to run the application
 
@@ -41,6 +44,10 @@ docker run -p 8000:8000 resumeio-to-pdf
 ```
 
 Open your browser and access http://localhost:8000
+
+Running outside Docker additionally needs Node.js 18 or newer on the `PATH`, since the rendering worker
+runs there. On the first render the worker and its chunks (~3.8 MB) are downloaded from resume.io into
+`/tmp/resumeio-worker`, or into `$RESUMEIO_WORKER_CACHE` when set.
 
 ### Disclaimer
 

--- a/app/api/api.py
+++ b/app/api/api.py
@@ -1,3 +1,4 @@
+import re
 from typing import Annotated
 
 from fastapi import APIRouter, Body, Path, Query, Request, Response
@@ -7,6 +8,8 @@ from fastapi.templating import Jinja2Templates
 from app.schemas.resumeio import Extension
 from app.services.renderer import ResumeioRenderer
 from app.services.resumeio import ResumeioDownloader
+
+UNSAFE_FILENAME = re.compile(r"[^A-Za-z0-9._-]")
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -33,7 +36,7 @@ def render_resume(
         A PDF representation of the resume with appropriate headers for inline display.
     """
     renderer = ResumeioRenderer(document=document, locale=locale)
-    name = document.get("renderingToken") or document.get("id") or "resume"
+    name = pdf_filename(document)
     return Response(
         renderer.generate_pdf(),
         media_type="application/pdf",
@@ -91,3 +94,21 @@ def index(request: Request):
         "index.html",
         {"request": request},
     )
+
+
+def pdf_filename(document: dict) -> str:
+    """
+    Build a filename that is safe to put in a Content-Disposition header.
+
+    Parameters
+    ----------
+    document : dict
+        Resume document, whose identifiers are supplied by the client.
+
+    Returns
+    -------
+    str
+        File name without an extension, stripped of quotes, separators and control characters.
+    """
+    name = str(document.get("renderingToken") or document.get("id") or "")
+    return UNSAFE_FILENAME.sub("_", name) or "resume"

--- a/app/api/api.py
+++ b/app/api/api.py
@@ -1,14 +1,44 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Path, Query, Request, Response
+from fastapi import APIRouter, Body, Path, Query, Request, Response
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
 from app.schemas.resumeio import Extension
+from app.services.renderer import ResumeioRenderer
 from app.services.resumeio import ResumeioDownloader
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
+
+
+@router.post("/render")
+def render_resume(
+    document: Annotated[dict, Body()],
+    locale: Annotated[str, Query(pattern="^[a-z]{2}(-[a-zA-Z]{2})?$")] = "en",
+):
+    """
+    Render every page of a resume.io document and return it as a PDF.
+
+    Parameters
+    ----------
+    document : dict
+        Resume document as served by https://resume.io/api/app/resumes/{id}.
+    locale : str, optional
+        Locale used to pick the renderer configuration, by default "en".
+
+    Returns
+    -------
+    fastapi.responses.Response
+        A PDF representation of the resume with appropriate headers for inline display.
+    """
+    renderer = ResumeioRenderer(document=document, locale=locale)
+    name = document.get("renderingToken") or document.get("id") or "resume"
+    return Response(
+        renderer.generate_pdf(),
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'inline; filename="{name}.pdf"'},
+    )
 
 
 @router.post("/download/{rendering_token}")

--- a/app/renderer/render.mjs
+++ b/app/renderer/render.mjs
@@ -1,0 +1,83 @@
+import { webcrypto } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import vm from "node:vm";
+
+const STARTUP_TIMEOUT_MS = 10_000;
+const RENDER_TIMEOUT_MS = 60_000;
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => (data += chunk));
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+const { document, config, assetsDir, entry, host } = JSON.parse(await readStdin());
+
+let settle;
+const rendered = new Promise((resolve, reject) => {
+  settle = { resolve, reject };
+});
+
+// A fresh context brings its own ECMAScript globals; anything else the worker needs has to be
+// handed over explicitly, and host functions must keep globalThis as their receiver or Node
+// rejects the call with ERR_INVALID_THIS.
+const context = vm.createContext();
+Object.assign(context, {
+  importScripts(...urls) {
+    for (const url of urls) {
+      const file = join(assetsDir, url.split("/").pop());
+      vm.runInContext(readFileSync(file, "utf8"), context, { filename: file });
+    }
+  },
+  postMessage(message) {
+    if (message.success) settle.resolve(message.result);
+    else settle.reject(new Error(message.error?.message || "worker reported failure"));
+  },
+  location: new URL(host),
+  console,
+  setTimeout: setTimeout.bind(globalThis),
+  clearTimeout: clearTimeout.bind(globalThis),
+  setInterval: setInterval.bind(globalThis),
+  clearInterval: clearInterval.bind(globalThis),
+  queueMicrotask: queueMicrotask.bind(globalThis),
+  structuredClone: structuredClone.bind(globalThis),
+  fetch: fetch.bind(globalThis),
+  btoa: btoa.bind(globalThis),
+  atob: atob.bind(globalThis),
+  TextEncoder,
+  TextDecoder,
+  URL,
+  URLSearchParams,
+  Blob,
+  Response,
+  Request,
+  Headers,
+  AbortController,
+  AbortSignal,
+  ReadableStream,
+  performance,
+  crypto: globalThis.crypto ?? webcrypto,
+  webpackChunk_rio_web_worker: [],
+});
+context.self = context;
+
+vm.runInContext(readFileSync(join(assetsDir, entry), "utf8"), context, { filename: entry });
+
+// The handler is registered only once the worker has pulled in its lazy chunks.
+for (let waited = 0; typeof context.onmessage !== "function"; waited += 10) {
+  if (waited > STARTUP_TIMEOUT_MS) throw new Error("worker did not register an onmessage handler");
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
+
+context.onmessage({ data: { taskId: "render", document, config, host } });
+
+const timeout = new Promise((_, reject) =>
+  setTimeout(() => reject(new Error("rendering timed out")), RENDER_TIMEOUT_MS).unref(),
+);
+
+process.stdout.write(Buffer.from(await Promise.race([rendered, timeout])));

--- a/app/renderer/render.mjs
+++ b/app/renderer/render.mjs
@@ -5,7 +5,15 @@ import vm from "node:vm";
 
 const STARTUP_TIMEOUT_MS = 10_000;
 const ALLOWED_HOST = /(^|\.)resume\.io$/;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const MAX_REDIRECTS = 5;
 const RENDER_TIMEOUT_MS = 60_000;
+
+function assertAllowed(target) {
+  if (target.protocol !== "data:" && !ALLOWED_HOST.test(target.hostname)) {
+    throw new Error(`blocked request to ${target.hostname || target.protocol}`);
+  }
+}
 
 function readStdin() {
   return new Promise((resolve, reject) => {
@@ -47,12 +55,22 @@ Object.assign(context, {
   clearInterval: clearInterval.bind(globalThis),
   queueMicrotask: queueMicrotask.bind(globalThis),
   structuredClone: structuredClone.bind(globalThis),
-  fetch(input, init) {
-    const target = new URL(input?.url ?? input, host);
-    if (target.protocol !== "data:" && !ALLOWED_HOST.test(target.hostname)) {
-      return Promise.reject(new Error(`blocked request to ${target.hostname}`));
+  async fetch(input, init) {
+    let target = new URL(input?.url ?? input, host);
+    assertAllowed(target);
+    let response = await fetch(input, { ...init, redirect: "manual" });
+
+    // Redirects are followed by hand so every hop is checked, not just the first one.
+    for (let hop = 0; REDIRECT_STATUSES.has(response.status); hop++) {
+      const location = response.headers.get("location");
+      if (!location) return response;
+      if (hop === MAX_REDIRECTS) throw new Error(`too many redirects for ${target}`);
+      target = new URL(location, target);
+      assertAllowed(target);
+      response = await fetch(target, { redirect: "manual" });
     }
-    return fetch(input, init);
+
+    return response;
   },
   btoa: btoa.bind(globalThis),
   atob: atob.bind(globalThis),

--- a/app/renderer/render.mjs
+++ b/app/renderer/render.mjs
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import vm from "node:vm";
 
 const STARTUP_TIMEOUT_MS = 10_000;
+const ALLOWED_HOST = /(^|\.)resume\.io$/;
 const RENDER_TIMEOUT_MS = 60_000;
 
 function readStdin() {
@@ -46,7 +47,13 @@ Object.assign(context, {
   clearInterval: clearInterval.bind(globalThis),
   queueMicrotask: queueMicrotask.bind(globalThis),
   structuredClone: structuredClone.bind(globalThis),
-  fetch: fetch.bind(globalThis),
+  fetch(input, init) {
+    const target = new URL(input?.url ?? input, host);
+    if (target.protocol !== "data:" && !ALLOWED_HOST.test(target.hostname)) {
+      return Promise.reject(new Error(`blocked request to ${target.hostname}`));
+    }
+    return fetch(input, init);
+  },
   btoa: btoa.bind(globalThis),
   atob: atob.bind(globalThis),
   TextEncoder,

--- a/app/services/assets.py
+++ b/app/services/assets.py
@@ -1,5 +1,6 @@
 import os
 import re
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -167,7 +168,10 @@ def _discover_worker_name() -> str:
 def _cache_asset(name: str) -> Path:
     path = CACHE_DIR / name
     if not path.exists():
-        path.write_bytes(_get(f"{RESUMEIO_ORIGIN}/assets/workers/{name}").content)
+        content = _get(f"{RESUMEIO_ORIGIN}/assets/workers/{name}").content
+        with tempfile.NamedTemporaryFile(dir=CACHE_DIR, delete=False) as partial:
+            partial.write(content)
+        os.replace(partial.name, path)
     return path
 
 

--- a/app/services/assets.py
+++ b/app/services/assets.py
@@ -1,0 +1,177 @@
+import os
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+from fastapi import HTTPException
+
+RESUMEIO_ORIGIN = "https://resume.io"
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/136.0.0.0 Safari/537.36"
+)
+CACHE_DIR = Path(os.getenv("RESUMEIO_WORKER_CACHE", "/tmp/resumeio-worker"))
+DISCOVERY_TTL_SECONDS = 3600
+
+BUILDER_BUNDLE = re.compile(r"/assets/js/builder-[a-f0-9]+\.js")
+CHUNK_NAMES = re.compile(r'(\d+):"([a-z-]+)"')
+CHUNK_HASHES = re.compile(r'(\d+):"([a-f0-9]{16})"')
+WORKER_FILE = re.compile(r'"workers/(rendering\.[a-f0-9]+\.js)"')
+CHUNK_FILES = re.compile(r'"workers/([A-Za-z0-9_.-]+\.js)"')
+VENDOR_HASHES = re.compile(r'"([a-f0-9]{20})"')
+
+_discovered: tuple[float, str] | None = None
+
+
+@dataclass
+class WorkerBundle:
+    """Location of the cached resume.io rendering worker.
+
+    Parameters
+    ----------
+    directory : Path
+        Directory holding the worker and every chunk it imports.
+    entry : str
+        File name of the worker itself.
+    """
+
+    directory: Path
+    entry: str
+
+
+def find_worker_name(rendering_core: str) -> str:
+    """Read the worker file name out of the rendering-core chunk.
+
+    Parameters
+    ----------
+    rendering_core : str
+        Source of the rendering-core chunk, which names the worker.
+
+    Returns
+    -------
+    str
+        File name of the rendering worker.
+    """
+    match = WORKER_FILE.search(rendering_core)
+    if not match:
+        raise LookupError("rendering-core does not reference a worker")
+    return match.group(1)
+
+
+def find_rendering_core_url(builder_bundle: str) -> str:
+    """Build the URL of the rendering-core chunk from the builder entry point.
+
+    Parameters
+    ----------
+    builder_bundle : str
+        Source of the builder entry point.
+
+    Returns
+    -------
+    str
+        Absolute URL of the rendering-core chunk.
+    """
+    names = dict(CHUNK_NAMES.findall(builder_bundle))
+    hashes = dict(CHUNK_HASHES.findall(builder_bundle))
+    chunk_ids = [chunk_id for chunk_id, name in names.items() if name == "rendering-core"]
+    if not chunk_ids or chunk_ids[0] not in hashes:
+        raise LookupError("builder bundle does not map a rendering-core chunk")
+    return f"{RESUMEIO_ORIGIN}/assets/chunk/rendering-core.{hashes[chunk_ids[0]]}.js"
+
+
+def find_chunk_names(worker: str) -> set[str]:
+    """Collect every chunk the worker may import at runtime.
+
+    Parameters
+    ----------
+    worker : str
+        Source of the rendering worker.
+
+    Returns
+    -------
+    set[str]
+        File names of the named and vendor chunks.
+    """
+    names = set(CHUNK_FILES.findall(worker))
+    marker = worker.find('"workers/vendors."')
+    if marker != -1:
+        table = worker[marker : marker + 6000]
+        names |= {f"vendors.{chunk_hash}.js" for chunk_hash in VENDOR_HASHES.findall(table[: table.find("})")])}
+    return names
+
+
+def ensure_bundle() -> WorkerBundle:
+    """Download the rendering worker and its chunks unless they are already cached.
+
+    Returns
+    -------
+    WorkerBundle
+        Cached worker ready to be executed by app/renderer/render.mjs.
+
+    Raises
+    ------
+    HTTPException
+        If resume.io does not serve the assets the worker is assembled from.
+    """
+    try:
+        entry = _discover_worker_name()
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        worker = _cache_asset(entry).read_text(encoding="utf-8")
+        for name in find_chunk_names(worker):
+            _cache_asset(name)
+    except (LookupError, requests.RequestException) as error:
+        raise HTTPException(status_code=502, detail=f"Unable to fetch the resume.io renderer: {error}") from error
+    return WorkerBundle(directory=CACHE_DIR, entry=entry)
+
+
+def fetch_renderer_config(locale: str) -> dict:
+    """Fetch the renderer configuration the worker expects alongside a resume.
+
+    Parameters
+    ----------
+    locale : str
+        Locale of the resume, e.g. "en".
+
+    Returns
+    -------
+    dict
+        Renderer configuration.
+    """
+    try:
+        response = _get(f"{RESUMEIO_ORIGIN}/api/app/general/renderer-config/{locale}")
+        return response.json()
+    except requests.RequestException as error:
+        raise HTTPException(status_code=502, detail=f"Unable to fetch the renderer config: {error}") from error
+
+
+def _discover_worker_name() -> str:
+    global _discovered
+    if _discovered and time.monotonic() - _discovered[0] < DISCOVERY_TTL_SECONDS:
+        return _discovered[1]
+
+    app_page = _get(f"{RESUMEIO_ORIGIN}/app/resumes").text
+    bundle_path = BUILDER_BUNDLE.search(app_page)
+    if not bundle_path:
+        raise LookupError("resume.io does not serve a builder bundle")
+    builder_bundle = _get(f"{RESUMEIO_ORIGIN}{bundle_path.group(0)}").text
+    rendering_core = _get(find_rendering_core_url(builder_bundle)).text
+
+    name = find_worker_name(rendering_core)
+    _discovered = (time.monotonic(), name)
+    return name
+
+
+def _cache_asset(name: str) -> Path:
+    path = CACHE_DIR / name
+    if not path.exists():
+        path.write_bytes(_get(f"{RESUMEIO_ORIGIN}/assets/workers/{name}").content)
+    return path
+
+
+def _get(url: str) -> requests.Response:
+    response = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=30)
+    response.raise_for_status()
+    return response

--- a/app/services/renderer.py
+++ b/app/services/renderer.py
@@ -1,0 +1,80 @@
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import HTTPException
+
+from app.services.assets import RESUMEIO_ORIGIN, ensure_bundle, fetch_renderer_config
+
+RENDER_SCRIPT = Path(__file__).parents[1] / "renderer" / "render.mjs"
+NODE_BINARY = os.getenv("RESUMEIO_NODE_BINARY", "node")
+RENDER_TIMEOUT_SECONDS = 120
+ERROR_LINE = re.compile(r"^[A-Za-z]*Error(\[[^\]]+\])?: ")
+
+
+@dataclass
+class ResumeioRenderer:
+    """Render a resume.io document into a PDF with resume.io's own rendering worker.
+
+    Parameters
+    ----------
+    document : dict
+        Resume document as served by https://resume.io/api/app/resumes/{id}.
+    locale : str, optional
+        Locale used to pick the renderer configuration, by default "en".
+    """
+
+    document: dict
+    locale: str = "en"
+
+    def generate_pdf(self) -> bytes:
+        """Render every page of the resume into a single PDF.
+
+        Returns
+        -------
+        bytes
+            PDF representation of the resume.
+
+        Raises
+        ------
+        HTTPException
+            If the renderer is unavailable or fails to produce a PDF.
+        """
+        bundle = ensure_bundle()
+        payload = json.dumps(
+            {
+                "document": self.document,
+                "config": fetch_renderer_config(self.locale),
+                "assetsDir": str(bundle.directory),
+                "entry": bundle.entry,
+                "host": RESUMEIO_ORIGIN,
+            },
+        )
+
+        try:
+            process = subprocess.run(
+                [NODE_BINARY, str(RENDER_SCRIPT)],
+                input=payload.encode(),
+                capture_output=True,
+                timeout=RENDER_TIMEOUT_SECONDS,
+            )
+        except FileNotFoundError as error:
+            raise HTTPException(status_code=500, detail=f"Node.js is required to render resumes: {error}") from error
+        except subprocess.TimeoutExpired as error:
+            raise HTTPException(status_code=504, detail="Rendering the resume timed out") from error
+
+        if process.returncode != 0 or not process.stdout.startswith(b"%PDF"):
+            raise HTTPException(status_code=502, detail=f"Unable to render the resume: {_last_error(process.stderr)}")
+
+        return process.stdout
+
+
+def _last_error(stderr: bytes) -> str:
+    lines = [line.strip() for line in stderr.decode("utf-8", "replace").splitlines() if line.strip()]
+    thrown = [line for line in lines if ERROR_LINE.match(line)]
+    if thrown:
+        return thrown[0]
+    return lines[0] if lines else "the renderer produced no output"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "black==26.3.1",
+    "pytest==9.1.1",
     "ruff==0.15.12",
 ]
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -248,7 +248,12 @@
         }
 
         const url = URL.createObjectURL(await response.blob());
-        window.open(url, '_blank');
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = (resume.renderingToken || resume.id || 'resume') + '.pdf';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
         setTimeout(() => URL.revokeObjectURL(url), 60000);
         renderText.style.display = 'block';
         renderLoader.style.display = 'none';

--- a/templates/index.html
+++ b/templates/index.html
@@ -142,10 +142,21 @@
         <a href="https://www.buymeacoffee.com/felipeall" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 40px !important;width: 160px !important;" ></a>
     </div>
     <h1 class="title">Resume.io to PDF</h1>
+    <form method="post" class="resume_form" id="renderForm">
+        <textarea class="resume" id="documentInput" name="document" rows="8" placeholder="Paste the JSON from https://resume.io/api/app/resumes/{id} to get every page" aria-label="Resume JSON"></textarea>
+        <span class="error" id="renderError">Paste the resume JSON, not the `renderingToken`</span>
+        <button id="render-btn" class="btn" type="submit"><span id="render-text">Download all pages</span>
+            <svg id="render-loader" width="23" height="23" stroke="#fff" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <g class="spinner_V8m1">
+                    <circle cx="12" cy="12" r="9.5" fill="none" stroke-width="3"></circle>
+                </g>
+            </svg>
+        </button>
+    </form>
     <form method="post" class="resume_form" id="downloadForm">
         <input type="text" class="resume" name="rendering_token" placeholder="Enter your resume `renderingToken`" aria-label="Id" maxlength="24">
         <span class="error">Your resume `renderingToken` must be a 24-character alphanumeric string</span>
-        <button id="submit-btn" class="btn" type="submit"><span id="submit-text">Download</span>
+        <button id="submit-btn" class="btn" type="submit"><span id="submit-text">Download first page</span>
             <svg id="loader" width="23" height="23" stroke="#fff" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <g class="spinner_V8m1">
                     <circle cx="12" cy="12" r="9.5" fill="none" stroke-width="3"></circle>
@@ -190,6 +201,57 @@
         document.getElementById('submit-text').style.display = 'none';
         document.getElementById('loader').style.display = 'block';
         this.submit();
+    });
+
+    const renderForm = document.getElementById("renderForm");
+    const documentInput = document.getElementById("documentInput");
+    const renderError = document.getElementById("renderError");
+    const renderText = document.getElementById("render-text");
+    const renderLoader = document.getElementById("render-loader");
+
+    const failRender = (message) => {
+        renderError.textContent = message;
+        renderError.style.display = 'block';
+        documentInput.classList.add('error-border');
+        documentInput.classList.remove('shake');
+        setTimeout(() => documentInput.classList.add('shake'), 100);
+        renderText.style.display = 'block';
+        renderLoader.style.display = 'none';
+    };
+
+    renderForm.addEventListener("submit", async function (e) {
+        e.preventDefault();
+
+        let resume;
+        try {
+            resume = JSON.parse(documentInput.value);
+        } catch {
+            failRender('Paste the resume JSON, not the `renderingToken`');
+            return;
+        }
+
+        renderError.style.display = 'none';
+        documentInput.classList.remove('error-border', 'shake');
+        renderText.style.display = 'none';
+        renderLoader.style.display = 'block';
+
+        const response = await fetch('/render?locale=' + encodeURIComponent(resume.locale || 'en'), {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(resume),
+        });
+
+        if (!response.ok) {
+            const error = await response.json().catch(() => ({}));
+            failRender(error.detail || 'Unable to render this resume');
+            return;
+        }
+
+        const url = URL.createObjectURL(await response.blob());
+        window.open(url, '_blank');
+        setTimeout(() => URL.revokeObjectURL(url), 60000);
+        renderText.style.display = 'block';
+        renderLoader.style.display = 'none';
     });
 </script>
 </body>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,18 @@
+from app.api.api import pdf_filename
+
+
+def test_pdf_filename_prefers_the_rendering_token():
+    assert pdf_filename({"renderingToken": "jLV8C4pXYQ1SMoHA4HLcEZr1", "id": 1}) == "jLV8C4pXYQ1SMoHA4HLcEZr1"
+
+
+def test_pdf_filename_falls_back_to_the_id():
+    assert pdf_filename({"id": 57400158}) == "57400158"
+
+
+def test_pdf_filename_strips_header_breaking_characters():
+    assert pdf_filename({"renderingToken": 'a"b\r\nX-Injected: 1'}) == "a_b__X-Injected__1"
+
+
+def test_pdf_filename_without_usable_identifiers():
+    assert pdf_filename({"renderingToken": "///"}) == "___"
+    assert pdf_filename({}) == "resume"

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,42 @@
+import pytest
+
+from app.services.assets import find_chunk_names, find_rendering_core_url, find_worker_name
+
+BUILDER_BUNDLE = (
+    'c.u=e=>"chunk/"+(({184:"misc",3525:"pdf-preview-renderer",9148:"rendering-core"})[e]||e)'
+    '+"."+({184:"0945f5e9412e9756",3525:"3917ea2d35a941e0",9148:"e0abc25e11002fd3"})[e]+".js"'
+)
+RENDERING_CORE = 'u=new Worker(new URL(e.p+e.u(961),e.b),{name:"rendering"});e.u=()=>"workers/rendering.be47e5a3.js"'
+WORKER = (
+    'd.u=e=>403===e?"workers/403.320a32cc6e386fcb17ce.js":972===e?"workers/972.151951a3f1e8ef2edf45.js"'
+    ':"workers/vendors."+({36:"551c1290911e384152f8",138:"327b58d20d235ea59b9f"})[e]+".js"'
+)
+
+
+def test_find_rendering_core_url():
+    assert find_rendering_core_url(BUILDER_BUNDLE) == (
+        "https://resume.io/assets/chunk/rendering-core.e0abc25e11002fd3.js"
+    )
+
+
+def test_find_rendering_core_url_without_the_chunk():
+    with pytest.raises(LookupError):
+        find_rendering_core_url('c.u=e=>"chunk/"+(({184:"misc"})[e]||e)+"."+({184:"0945f5e9412e9756"})[e]+".js"')
+
+
+def test_find_worker_name():
+    assert find_worker_name(RENDERING_CORE) == "rendering.be47e5a3.js"
+
+
+def test_find_worker_name_without_a_worker():
+    with pytest.raises(LookupError):
+        find_worker_name("u=new Worker(new URL(e.p+e.u(961),e.b))")
+
+
+def test_find_chunk_names_covers_named_and_vendor_chunks():
+    assert find_chunk_names(WORKER) == {
+        "403.320a32cc6e386fcb17ce.js",
+        "972.151951a3f1e8ef2edf45.js",
+        "vendors.551c1290911e384152f8.js",
+        "vendors.327b58d20d235ea59b9f.js",
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -172,6 +172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -327,6 +336,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.11.7"
 source = { registry = "https://pypi.org/simple" }
@@ -384,6 +402,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151 },
+]
+
+[[package]]
 name = "pytesseract"
 version = "0.3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -394,6 +421,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/a6/7d679b83c285974a7cb94d739b461fa7e7a9b17a3abfd7bf6cbc5c2394b0/pytesseract-0.3.13.tar.gz", hash = "sha256:4bf5f880c99406f52a3cfc2633e42d9dc67615e69d8a509d74867d3baddb5db9", size = 17689 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/33/8312d7ce74670c9d39a532b2c246a853861120486be9443eebf048043637/pytesseract-0.3.13-py3-none-any.whl", hash = "sha256:7a99c6c2ac598360693d83a416e36e0b33a67638bb9d77fdcac094a3589d4b34", size = 14705 },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536 },
 ]
 
 [[package]]
@@ -456,6 +499,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "black" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -472,6 +516,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "black", specifier = "==26.3.1" },
+    { name = "pytest", specifier = "==9.1.1" },
     { name = "ruff", specifier = "==0.15.12" },
 ]
 


### PR DESCRIPTION
Fixes the single-page limitation behind #73 / #71 by rendering resumes the way resume.io itself does. Full analysis of why the current endpoint cannot be repaired is in #78.

### Why the image endpoint is a dead end

`ssr.resume.tools/to-image/{token}-N` returns a 1282-byte placeholder for every `N` but the first, and `meta/{token}` reports one page for a resume that has three. Neither `&page=N`, zero-padded indices, `pages=all`, the old `ssid-` prefix, a `resume.io` `Referer`, dropping `cache` nor changing `size` brings the other pages back. The editor itself no longer touches that host — it builds the PDF in a web worker and paints it with pdf.js.

### What this PR does

Drives that same worker from Python:

```
POST /render   ← resume JSON from /api/app/resumes/{id}
   → node app/renderer/render.mjs
   → worker.postMessage({ document, config, host, taskId })
   → ArrayBuffer  →  multi-page PDF
```

Output is vector text with embedded font subsets, so the OCR step is not involved and the 2000px resolution cap does not apply.

`/download/{rendering_token}` is untouched and still serves the single-page OCR path for anyone without a session.

### Notes for review

* **Nothing proprietary is committed.** The worker file name changes on every deploy, so it is discovered at runtime through `/app/resumes` → `builder-*.js` → `rendering-core.*.js`, and the worker plus its 18 chunks (~3.8 MB) are cached under `/tmp/resumeio-worker` or `$RESUMEIO_WORKER_CACHE`. Every one of those assets, and `renderer-config`, is served without authentication.
* **No headless browser.** A `vm` context with an `importScripts` shim is enough. Two things that are easy to get wrong: the context has to be a fresh `vm.createContext()` rather than something inheriting from `globalThis`, or Node rejects timer calls with `ERR_INVALID_THIS`; and `onmessage` has to be polled for, because the worker registers it only after pulling in its lazy chunks.
* **The document goes in flat**, exactly as `/api/app/resumes/{id}` returns it. Wrapping it as `{ resume: document }` fails with `Cannot read properties of undefined (reading 'primaryFonts')` — worth knowing for #77, where that nesting makes the renderer fall back to the image endpoint.
* **Input had to change.** The document JSON requires the user's session, so a `renderingToken` alone is no longer enough — same conclusion #76 reached.
* **`uv.lock`** is hand-trimmed to the 45 added lines for `pytest`; regenerating it with a current `uv` rewrites all 584 lines with `revision = 3` and `upload-time` metadata, which seemed like noise to put in front of you. `uv sync --frozen` accepts it as is.

### Testing

* `ruff check` — clean; `pytest tests` — 5 passing, covering the bundle parsing with no network and no Node, so CI stays fast.
* A real 3-page resume through `POST /render`: `200`, 59043 bytes, 3 pages, selectable Cyrillic and Latin text, layout identical to the editor preview.
* A malformed document returns `502` with the renderer's own message; an invalid locale returns `422`.
* `uv sync --frozen` and a synthetic fixture render (2 pages, EBGaramond subsets embedded).

### The question worth asking first

This executes resume.io's bundle server-side. #76 and #77 take the same route, and if you would rather not carry that at all, say so and I will close this — documenting the one-page limit is the honest alternative. I went with runtime discovery plus a cache instead of vendoring the bundle so the repository stays free of third-party JavaScript, but the tradeoff is real: vendoring is hermetic, discovery breaks if the webpack layout changes. Happy to switch, split this up, or drop the UI part if you prefer an API-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full multi-page PDF downloads using Resume.io resume JSON.
  - Added locale-aware rendering with loading and error feedback.
  - Clarified that token-based downloads retrieve only the first page.
  - Added automatic renderer asset downloading and caching.
  - Generated PDFs now download with safe, descriptive filenames.
- **Documentation**
  - Added guidance for obtaining resume JSON, rendering PDFs, Node.js requirements, and asset storage.
- **Chores**
  - Docker images now include Node.js for PDF rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->